### PR TITLE
Avoid TypeError in game_info.py

### DIFF
--- a/carball/json_parser/game_info.py
+++ b/carball/json_parser/game_info.py
@@ -31,11 +31,13 @@ class GameInfo:
         self.match_guid = actor_data.get('ProjectX.GRI_X:MatchGUID', '')
         self.playlist = actor_data['ProjectX.GRI_X:ReplicatedGamePlaylist']
         self.mutator_index = actor_data.get('ProjectX.GRI_X:ReplicatedGameMutatorIndex', 0)
-
-        if 'TAGame.GameEvent_Soccar_TA:SubRulesArchetype' in game_event_actor:
-            # Only used for rumble stats
-            # TODO can this contain any other mutators?
-            self.rumble_mutator = objects[game_event_actor['TAGame.GameEvent_Soccar_TA:SubRulesArchetype']]
-
+        try:
+            if 'TAGame.GameEvent_Soccar_TA:SubRulesArchetype' in game_event_actor:
+                # Only used for rumble stats
+                # TODO can this contain any other mutators?
+                self.rumble_mutator = objects[game_event_actor['TAGame.GameEvent_Soccar_TA:SubRulesArchetype']]
+        except TypeError:
+            pass
+        
         logger.info('Created game info from actor')
         return self


### PR DESCRIPTION
I had some problems while parsing older replays (Season 1 RLCS), e.g. [

here](https://drive.google.com/open?id=1oq5XePu1xn-4Su-mB1TJSPuI1NKbfmgV) .
During the process of calling Game -> Game.initialize() -> Game.parse_all_data() -> GameInfo().parse_game_info_actor() and the following conditional
```
if 'TAGame.GameEvent_Soccar_TA:SubRulesArchetype' in game_event_actor:
                self.rumble_mutator = objects[game_event_actor['TAGame.GameEvent_Soccar_TA:SubRulesArchetype']]
```

I got the following error: 
```
<ipython-input-69-c38ae7f74375> in parse_game_info_actor(self, actor_data, game_event_actor, objects)
    604         self.playlist = actor_data['ProjectX.GRI_X:ReplicatedGamePlaylist']
    605         self.mutator_index = actor_data.get('ProjectX.GRI_X:ReplicatedGameMutatorIndex', 0)
--> 606         if 'TAGame.GameEvent_Soccar_TA:SubRulesArchetype' in game_event_actor:
    607                 # Only used for rumble stats
    608                 # TODO can this contain any other mutators?

TypeError: argument of type 'NoneType' is not iterable
```

The problem is, that some (older?) replay files yield a dict containing the key 'soccar_game_event_actor' but without content (NoneType). 
An easy fix was to catch the exception and continue without setting the rumble_mutator.